### PR TITLE
fix(update): modify install script to fix update issue

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -81,7 +81,11 @@ command: "helm-diff"
 END
 	ln -s . "${install_path}/helm-diff"
 
-	if command -v helm >/dev/null && ! helm plugin list | sed 1d | grep -qs '^diff[[:space:]]'; then
+  # Check if helm is installed and helm-diff is installed, then uninstall helm-diff to recreate symlink to correct version
+  if command -v helm >/dev/null && helm plugin list | sed 1d | grep -qs '^diff[[:space:]]'; then
+      helm plugin uninstall diff || true
+      helm plugin install "${install_path}/helm-diff" || true
+  elif command -v helm >/dev/null && ! helm plugin list | sed 1d | grep -qs '^diff[[:space:]]'; then
 		helm plugin install "${install_path}/helm-diff" || true
 	fi
 }


### PR DESCRIPTION
When updating the plugin, asdf installs the new version before going through the uninstall of the old version.

Because of this, `/home/user/.local/share/helm/plugins/helm-diff` is a symbolic link to a deleted version.

Running the uninstall step in the case an old version exists deletes the _soon to be broken_ symlink to correctly point to the new version with the command `helm plugin install`.