### PR TITLE
Define actual version in plugin.yaml

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -73,7 +73,7 @@ function install() {
 
 	cat >"${install_path}/plugin.yaml" <<END
 name: "diff"
-version: "asdf"
+version: "$version"
 usage: "Preview helm upgrade changes as a diff"
 description: "Preview helm upgrade changes as a diff"
 useTunnel: true


### PR DESCRIPTION
Some tools expect `version` to match the [semver](https://semver.org/) spec. `version: asdf` throws an error. This information is already available `bin/install`, just needs to be used.